### PR TITLE
jQuery find() requires '#' to find elements by id

### DIFF
--- a/badger.js
+++ b/badger.js
@@ -16,20 +16,20 @@
 			// use the badge id specified
 			? defaults.badge_id 
 			// create a random id; jquery does not like ids with periods in them
-			: '#Badger_' + Math.random().toString().replace('.',''); 
+			: 'Badger_' + Math.random().toString().replace('.',''); 
 		var the_badge = badge_id+'_badge';
-		var badgerExists = this.find(badge_id).html();
+		var badgerExists = this.find('#'+badge_id).html();
 
-  		// Clear the badge
-  		if(!badge)
-  			{
-  			if(badgerExists)
-  				{ this.find(badge_id).remove(); }
-  			}
-  		else
-  			{
+		// Clear the badge
+		if(!badge)
+			{
+			if(badgerExists)
+				{ this.find('#'+badge_id).remove(); }
+			}
+		else
+			{
 			// Figuring out badge data
-			var oldBadge = this.find(the_badge).text();
+			var oldBadge = this.find('#'+the_badge).text();
 			if(badge.charAt(0)=='+')
 				{
 				if(isNaN(badge.substr(1)))
@@ -48,15 +48,15 @@
 
 			// Don't add duplicates
 			if(badgerExists)
-				{ this.find(the_badge).html(badge); }
+				{ this.find('#'+the_badge).html(badge); }
 			else
 				{ this.append('<div class="badger-outter" id="'+badge_id+'"><div class="badger-inner"><p class="badger-badge" id="'+the_badge+'">'+badge+'</p></div></div>'); }
 
 			// Badger text or number class
 			if(isNaN(badge))
-				{ this.find(the_badge).removeClass('badger-number').addClass('badger-text'); }
+				{ this.find('#'+the_badge).removeClass('badger-number').addClass('badger-text'); }
 			else
-				{ this.find(the_badge).removeClass('badger-text').addClass('badger-number'); }
+				{ this.find('#'+the_badge).removeClass('badger-text').addClass('badger-number'); }
 			// Send back badge
 			if(callback) { callback(badge); }
 			}


### PR DESCRIPTION
Much of this code was not working because jquery find() needed a '#' before the id. Multiple instances were being created when "+1" was passed to the badger.  This is also why the badger-text and badger-number classes were never being applied.  The leading '#' in the self generated id was actually being put in the elements id.  The css should be adjusted also because the badger- number and badger-text classes are now being applied.
